### PR TITLE
Trying to reproduce regex regression in master

### DIFF
--- a/regress/github-regex/run
+++ b/regress/github-regex/run
@@ -1,0 +1,17 @@
+#!/bin/sh
+# This regression test is a part of SIPp.
+# Author: Walter Doekes, OSSO B.V., 2016
+. "`dirname "$0"`/../functions"; init
+
+sippfg -m 1 -sf uas.xml -p 5070 >/dev/null 2>&1 &
+job=$!
+sippfg -m 1 -sf uac.xml 127.0.0.1:5070 \
+    -timeout 4 -timeout_error >/dev/null 2>&1
+status=$?
+wait $job || status=1
+
+if test $status -eq 0; then
+    ok
+else
+    fail "bad R-URI through [next_url]?"
+fi

--- a/regress/github-regex/uac.xml
+++ b/regress/github-regex/uac.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <send retrans="500" start_txn="invite">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv response="200" response_txn="invite" rrs="true"/>
+
+  <send retrans="500" ack_txn="invite">
+    <![CDATA[
+
+      ACK [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <timewait milliseconds="500"/>
+</scenario>

--- a/regress/github-regex/uas.xml
+++ b/regress/github-regex/uas.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <recv request="INVITE"/>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag00[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:user@1.2.3.4:58292;transport=tcp;alias=5.5.5.5~58292~2>;+sip.instance="<urn:uuid:0f35feab-c878-4622-a94e-b2e6e812b177>"
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv request="ACK">
+    <action>
+      <!-- This test should always fail -->
+      <ereg regexp="NO MATCH" search_in="msg" check_it="true" check_it_inverse="false" assign_to="all,ruri"/>
+      <ereg regexp="NO MATCH" search_in="msg" check_it="true" check_it_inverse="true" assign_to="all,ruri"/>
+    </action>
+  </recv>
+  <Reference variables="all,ruri"/>
+</scenario>


### PR DESCRIPTION
Instructions for running SIPp regression tests as reported by @JuanTecedor:

1. Install dependencies (at least in PopOs! I needed these): `build-essential cmake make gcc libcurses-ocaml-dev libsctp-dev libpcap-dev`
2. cmake .  and make  (here I'm assuming bug is not dependent on `-DUSE_SSL=1 -DUSE_SCTP=1 -DUSE_PCAP=1 -DUSE_GSL=1` , I did not find it to make a difference but further testing is needed
3. `cd regress`
4. I recommend deleting all tests but` github-regex`  to speedup testing (maybe there is a posibility of filtering tests, but I did not found it)
5. `./runtests`